### PR TITLE
Clarify limitations of 'Open' for PsychPortAudio

### DIFF
--- a/docs/PsychPortAudio-Open.md
+++ b/docs/PsychPortAudio-Open.md
@@ -6,10 +6,11 @@ pahandle = PsychPortAudio('Open' [, deviceid][, mode][, reqlatencyclass][, freq]
 Open a [PortAudio](PortAudio) audio device and initialize it. Returns a 'pahandle' device  
 handle for the device.  
   
-On most operating systems you can open each physical sound device only once per  
-running session. If you feel the need to call 'Open' multiple times on the same  
-audio device, read the section about slave devices and the help 'PsychPortAudio  
-[OpenSlave](OpenSlave)?' instead for a suitable solution.  
+On most operating systems you can open only one stream at a time for each 
+physical device. If you feel the need to call 'Open' multiple times on the same 
+audio device without calling 'Close' in-between, read the section about slave 
+devices and the help 'PsychPortAudio [OpenSlave](PsychPortAudio-OpenSlave)?' 
+instead for a suitable solution.  
 All parameters are optional and have reasonable defaults. 'deviceid' Index to  
 select amongst multiple logical audio devices supported by [PortAudio](PortAudio). Defaults  
 to whatever the systems default sound device is. Different device id's may  


### PR DESCRIPTION
The wording of the documentation for PsychPortAudio('Open') gives the impression that only one stream per device can ever be opened, but calling `run` from [the Python demo for PPA](https://github.com/Psychtoolbox-3/Psychtoolbox-3/blob/master/PsychPython/demos/ppatest_pythonic.py), which opens and closes a new stream each time, works fine when called multiple times in a single session. The proposed wording clarifies that the limitation is one stream *at a time* rather than one stream *total*.

The link to docs for 'OpenSlave' was also broken, so I added the prefix `PsychPortAudio-` while in the neighbourhood.